### PR TITLE
Add how to development section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 Collaborative mapping without internet connectivity
 ===================================================
 
+How to development
+-------
+
+```
+git clone https://github.com/vmx/colleemap.git
+cd colleemap
+npm ci
+npm run dev
+```
+
+Open https://localhost:5173/
+
+**NOTE**: It's `https://`, not `http://`!
+
 License
 -------
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0 OR MIT",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "test": "pta ./test/"


### PR DESCRIPTION
The basic order to start development has been added to README.md.
In particular, the fact that it must be `https://localhost:5173/` and not `http://localhost:5173/` should be in README.md!
My development environment required the `--host` option for `vite`, so I added that too.