### PR TITLE
Switch to another camera when click on the video area

### DIFF
--- a/src/lib/Scan.svelte
+++ b/src/lib/Scan.svelte
@@ -184,6 +184,13 @@
     qrScanner = null;
   })
 
+  let changeCamera = async () => {
+    const cameras = await QrScanner.listCameras();
+    console.log('cameras:', cameras)
+    const newCamera = cameras[Math.floor(Math.random() * cameras.length)];
+    qrScanner.setCamera(newCamera.id)
+  }
+
   let connect = async () => {
     scanState = "connecting"
 
@@ -230,7 +237,7 @@
 
 <div id="container">
 {#if scanState === "scanner"}
-  <video bind:this={video}></video>
+  <video bind:this={video} on:click={changeCamera}></video>
 {:else if scanState === "scanned"}
   <div class="connect" on:click={connect}>
     <p>Once the other peer has scanned your code, click here to</p>

--- a/src/lib/Scan.svelte
+++ b/src/lib/Scan.svelte
@@ -26,6 +26,7 @@
   const DNS6 = 55
 
   let video
+  let cameraId
   /// The scan state defines which elements are displayed.
   ///
   ///  - "scanner": QR-code scanner.
@@ -175,7 +176,9 @@
         highlightCodeOutline: true
       }
     )
-    await qrScanner.setCamera('environment')
+    const cameras = await QrScanner.listCameras(true)
+    cameraId = cameras[0].id
+    await qrScanner.setCamera(cameraId)
     qrScanner.start()
   })
 
@@ -187,8 +190,10 @@
   let changeCamera = async () => {
     const cameras = await QrScanner.listCameras();
     console.log('cameras:', cameras)
-    const newCamera = cameras[Math.floor(Math.random() * cameras.length)];
-    qrScanner.setCamera(newCamera.id)
+    const cameraIdx = cameras.findIndex((cam) => cam.id === cameraId)
+    const newCamera = cameras[cameraIdx + 1 < cameras.length ? cameraIdx + 1 : 0]
+    cameraId = newCamera.id
+    qrScanner.setCamera(cameraId)
   }
 
   let connect = async () => {


### PR DESCRIPTION
My laptop has several real and virtual cameras.
I couldn't capture the QR code without the proper camera, so I tried switching to a ~random~ another camera when I clicked on the video area.
Cameras are switched in the order in which they were acquired.
Please consider this change as I need this change for my trial and error colleemap!

[![Image from Gyazo](https://i.gyazo.com/196fb39e8d2e5615223308574ef95c71.gif)](https://gyazo.com/196fb39e8d2e5615223308574ef95c71)